### PR TITLE
Handling for empty values

### DIFF
--- a/lib/types/email.js
+++ b/lib/types/email.js
@@ -4,7 +4,11 @@ module.exports.loadType = function (db) {
   function Email (path, options) {
     db.SchemaTypes.String.call(this, path, options);
     function validateEmail (val) {
-      return /^[\+a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/.test(val);
+      if (val) {
+        return /^[\+a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/.test(val);
+      } else {
+        return null;
+      }
     }
     this.validate(validateEmail, 'email is invalid');
   }

--- a/lib/types/url.js
+++ b/lib/types/url.js
@@ -6,13 +6,19 @@ module.exports.loadType = function (db) {
     db.SchemaTypes.String.call(this, path, options);
     function validateUrl (val) {
       var urlRegexp = /(ftp|http|https):\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
-      return urlRegexp.test(val);
+      if (val) {
+        return urlRegexp.test(val);
+      } else {
+        return true;
+      }
     }
     this.validate(validateUrl, 'url is invalid');
   }
   Url.prototype.__proto__ = db.SchemaTypes.String.prototype;
   Url.prototype.cast = function (val) {
-    return module.exports.normalizeUrl(val);
+    if (val) {
+      return module.exports.normalizeUrl(val);
+    }
   };
   db.SchemaTypes.Url = Url
   db.Types.Url = String;


### PR DESCRIPTION
Do not normalise / validate empty / undefined values since otherwise the types cannot be used for non-required fields.